### PR TITLE
Added storage method on Postgres plugin

### DIFF
--- a/lib/kuby/plugins/rails_app/postgres.rb
+++ b/lib/kuby/plugins/rails_app/postgres.rb
@@ -63,6 +63,20 @@ module Kuby
             end
           end
         end
+        
+        def storage(amount)
+          database do
+            spec do
+              storage do
+                resources do
+                  requests do
+                    set :storage, amount
+                  end
+                end
+              end
+            end
+          end
+        end        
 
         def secret(&block)
           context = self


### PR DESCRIPTION
Got the following error message when trying to specify storage in kuby.rb for Postgres:

     undefined method `storage' for #<Kuby::Plugins::RailsApp::Postgres:0x00007fd8e8902ae0> (NoMethodError)

In mysql.rb this method was present at that level so I used that one.  (very well possible it's not ok, but I can try right :-)